### PR TITLE
Fix: problem of an infinitely open websocket connection

### DIFF
--- a/botasaurus_driver_cf_solve/core/browser.py
+++ b/botasaurus_driver_cf_solve/core/browser.py
@@ -419,7 +419,9 @@ class Browser:
         try:
             if self.connection:
                 self.connection.send(cdp.browser.close())
-                self.connection = None
+                # if leave the line <self.connection = None> here, then the condition <if self.connection:>
+                # will not be fulfilled in function <close_browser_connection()>
+                # and closing connection will not occur <self.connection.close()>
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
В коменте расписал в чём была проблема, но продублирую тут. 
если в функции `close_chrome()` оставить `self.connection = None`, то дальше по коду, когда выполняется функция `close_browser_connection()` не будет выполняться условие `if self.connection:` потому что self.connection уже None, и не будет происходить закрытие соединения `self.connection.close()`